### PR TITLE
DWT based nanosecond delay

### DIFF
--- a/cores/arduino/per/uart.cpp
+++ b/cores/arduino/per/uart.cpp
@@ -696,20 +696,22 @@ pin_alt pins_none = {{UVS_GPIOX, 0}, 255};
 //valid pins per periph, and the alt they're on
 pin_alt usart1_pins_tx[] = {{{UVS_GPIOB, 6}, GPIO_AF7_USART1},
                             {{UVS_GPIOB, 14}, GPIO_AF4_USART1},
-                            pins_none};
+                            {{UVS_GPIOA, 9}, GPIO_AF7_USART1}};
 pin_alt usart1_pins_rx[] = {{{UVS_GPIOB, 7}, GPIO_AF7_USART1},
                             {{UVS_GPIOB, 15}, GPIO_AF4_USART1},
-                            pins_none};
+                            {{UVS_GPIOA, 10}, GPIO_AF7_USART1}};
 
 pin_alt usart2_pins_tx[]
     = {{{UVS_GPIOA, 2}, GPIO_AF7_USART2}, pins_none, pins_none};
 pin_alt usart2_pins_rx[]
     = {{{UVS_GPIOA, 3}, GPIO_AF7_USART2}, pins_none, pins_none};
 
-pin_alt usart3_pins_tx[]
-    = {{{UVS_GPIOC, 10}, GPIO_AF7_USART3}, pins_none, pins_none};
-pin_alt usart3_pins_rx[]
-    = {{{UVS_GPIOC, 11}, GPIO_AF7_USART3}, pins_none, pins_none};
+pin_alt usart3_pins_tx[] = {{{UVS_GPIOC, 10}, GPIO_AF7_USART3},
+                            {{UVS_GPIOD, 8}, GPIO_AF7_USART3},
+                            pins_none};
+pin_alt usart3_pins_rx[] = {{{UVS_GPIOC, 11}, GPIO_AF7_USART3},
+                            {{UVS_GPIOD, 9}, GPIO_AF7_USART3},
+                            pins_none};
 
 pin_alt uart4_pins_tx[] = {{{UVS_GPIOB, 9}, GPIO_AF8_UART4},
                            {{UVS_GPIOC, 10}, GPIO_AF8_UART4},

--- a/cores/arduino/sys/system.cpp
+++ b/cores/arduino/sys/system.cpp
@@ -79,9 +79,6 @@ __attribute__((always_inline)) static inline void __JUMPTOQSPI()
 
 typedef void (*EntryPoint)(void);
 
-/** Static variable to hold DWT ticks per microsecond */
-static uint32_t usTicks = 0;
-
 // System Level C functions and IRQ Handlers
 extern "C"
 {
@@ -90,6 +87,21 @@ extern "C"
         HAL_IncTick();
         HAL_SYSTICK_IRQHandler();
     }
+
+/** Static variable to hold DWT ticks per microsecond */
+static uint32_t usTicks;
+
+static inline uint32_t ticks(void) 
+{
+    return DWT->CYCCNT;
+}
+
+void delayNanos(int32_t ns)
+{
+    const uint32_t startTicks = DWT->CYCCNT;
+    const uint32_t ticksToWait = (ns * usTicks) / 1000;
+    while (DWT->CYCCNT - startTicks <= ticksToWait);
+}
 
     /** USB IRQ Handlers since they are shared resources for multiple classes */
     extern HCD_HandleTypeDef hhcd_USB_OTG_HS;

--- a/cores/arduino/sys/system.cpp
+++ b/cores/arduino/sys/system.cpp
@@ -362,26 +362,6 @@ void System::DelayUs(uint32_t delay_us)
     }
 }
 
-void System::DelayNs(int32_t delay_ns)
-{
-    const uint32_t start = GetTicksDWT();
-    const uint32_t ticks = (delay_ns * usTicks) / 1000;
-    while (GetTicksDWT() - start <= ticks)
-    {
-        asm volatile("" ::: "memory"); // Compiler barrier
-    }
-}
-
-void System::DelayTicks(uint32_t ticks)
-{
-    if (ticks == 0) return;
-    uint32_t start = GetTicksDWT();
-    while ((GetTicksDWT() - start) < ticks)
-    {
-        asm volatile("" ::: "memory"); // Compiler barrier to prevent optimization
-    }
-}
-
 void System::ResetToBootloader(BootloaderMode mode)
 {
     if(mode == BootloaderMode::STM)

--- a/cores/arduino/sys/system.h
+++ b/cores/arduino/sys/system.h
@@ -144,50 +144,60 @@ class System
 
     /** Convert nanoseconds to ticks (CPU cycles) from CMSIS SystemCoreClock
      ** @param ns Number of nanoseconds to convert.
-     ** @return uint32_t Number of cycles per microsecond. */
+     ** @return uint32_t Number of cycles for a given nsec delay. */
     static uint32_t NsToTicks(uint32_t ns)
     {
-        /* Using 64-bit intermediate to avoid overflow,
-           add . */
+        /** Using 64-bit intermediate to avoid overflow, adding
+         ** 999'999'999 and dividing by 1'000'000'000 rounds up. */
         uint64_t cycles = ((uint64_t)SystemCoreClock * ns + 999'999'999ULL) / 1'000'000'000ULL;
-
-        // Ensure at least one cycle:
-        if (cycles == 0) cycles = 1;
-
         return (uint32_t)cycles;
     }
 
-    /** Blocking Delay using internal timer to wait
-     ** \param ticks Number of DWT ticks to delay */
+    /** Blocking Delay using NOPs / DWT timer to wait
+     ** \param ticks Number of cpu ticks to delay */
     static inline __attribute__((always_inline))
-#if 0 // gls
-    void DelayTicks(uint32_t ticks)
+    void DelayTicks( uint32_t ticks )
     {
-        // Ensure at least one cycle to prevent an infinite loop
-        if (ticks == 0) return;
-        uint32_t start = DWT->CYCCNT;
-        // Busy-wait until DWT->CYCCNT - start >= ticks
-        while ((uint32_t)(DWT->CYCCNT - start) < ticks) {}
-    }
-#else
-    void DelayTicks(uint32_t ticks)
-    {
-        if (ticks == 0)
-        {
-            return;
-        }
-        else if (ticks <= 50)
-        {
-            for (uint32_t i = 0; i < ticks; i++)
-                __NOP();
-        }
-        else
-        {
+        if ( ticks <= 25 ) {
+            // Use a switch-case fallthrough to generate a linear sequence of NOPs.
+            // The compiler often creates a jump table or a minimal branch sequence here.
+            // Starting from the largest case ensures that if we request 25 ticks,
+            // we execute 25 NOPs, and if fewer ticks are requested, we jump into
+            // the middle of the chain.
+            switch ( ticks ) {
+            case 25: __NOP();
+            case 24: __NOP();
+            case 23: __NOP();
+            case 22: __NOP();
+            case 21: __NOP();
+            case 20: __NOP();
+            case 19: __NOP();
+            case 18: __NOP();
+            case 17: __NOP();
+            case 16: __NOP();
+            case 15: __NOP();
+            case 14: __NOP();
+            case 13: __NOP();
+            case 12: __NOP();
+            case 11: __NOP();
+            case 10: __NOP();
+            case 9: __NOP();
+            case 8: __NOP();
+            case 7: __NOP();
+            case 6: __NOP();
+            case 5: __NOP();
+            case 4: __NOP();
+            case 3: __NOP();
+            case 2: __NOP();
+            case 1: __NOP();
+            default:
+                break;
+            }
+        } else {
             uint32_t start = DWT->CYCCNT;
-            while ((DWT->CYCCNT - start) < ticks) { }
+            while ( ( DWT->CYCCNT - start ) < ticks ) { }
         }
     }
-#endif
 
     /** Specify how the board should return to the bootloader
      * \param STM return to the STM32-provided

--- a/cores/arduino/sys/system.h
+++ b/cores/arduino/sys/system.h
@@ -155,8 +155,8 @@ class System
 
     /** Blocking Delay using NOPs / DWT timer to wait
      ** \param ticks Number of cpu ticks to delay */
-    static inline __attribute__((always_inline))
-    void DelayTicks( uint32_t ticks )
+    // static inline __attribute__((always_inline)) void DelayTicks( uint32_t ticks )
+    static void DelayTicks( uint32_t ticks )
     {
         if ( ticks <= 25 ) {
             // Use a switch-case fallthrough to generate a linear sequence of NOPs.

--- a/examples/DWT/DWT.cpp
+++ b/examples/DWT/DWT.cpp
@@ -4,6 +4,10 @@
 #include "stm32h7xx_ll_bus.h"
 
 // #define USE_HAL
+#define TEST_RCC_GPIO_CLOCK_ENABLE() __HAL_RCC_GPIOA_CLK_ENABLE()
+#define TEST_GPIO_PORT GPIOA
+#define TEST_GPIO_PIN GPIO_PIN_5
+#define TEST_LL_GPIO_PIN LL_GPIO_PIN_5
 
 extern "C" void delayNanos(int32_t ns);
 
@@ -23,7 +27,7 @@ int main(void)
     hardware.Init();
 
     /* Enable the GPIO Clock */
-    __HAL_RCC_GPIOA_CLK_ENABLE();
+    TEST_RCC_GPIO_CLOCK_ENABLE();
 
 #if defined(USE_HAL)
   GPIO_InitTypeDef  GPIO_InitStruct;
@@ -32,20 +36,20 @@ int main(void)
   GPIO_InitStruct.Pull  = GPIO_PULLUP;
   GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
 
-  GPIO_InitStruct.Pin = GPIO_PIN_5;
-  HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+  GPIO_InitStruct.Pin = TEST_GPIO_PIN;
+  HAL_GPIO_Init(TEST_GPIO_PORT, &GPIO_InitStruct);
 #else
     /* Configure IO in output push-pull mode to drive external LED1 */
-    LL_GPIO_SetPinMode(GPIOA, LL_GPIO_PIN_5, LL_GPIO_MODE_OUTPUT);
+    LL_GPIO_SetPinMode(TEST_GPIO_PORT, TEST_LL_GPIO_PIN, LL_GPIO_MODE_OUTPUT);
     /* Reset value is LL_GPIO_OUTPUT_PUSHPULL */
-    LL_GPIO_SetPinOutputType(GPIOA, LL_GPIO_PIN_5, LL_GPIO_OUTPUT_PUSHPULL);
+    LL_GPIO_SetPinOutputType(TEST_GPIO_PORT, TEST_LL_GPIO_PIN, LL_GPIO_OUTPUT_PUSHPULL);
     /* Reset value is LL_GPIO_SPEED_FREQ_LOW */
-    LL_GPIO_SetPinSpeed(GPIOA, LL_GPIO_PIN_5, LL_GPIO_SPEED_FREQ_VERY_HIGH);
+    LL_GPIO_SetPinSpeed(TEST_GPIO_PORT, TEST_LL_GPIO_PIN, LL_GPIO_SPEED_FREQ_VERY_HIGH);
     /* Reset value is LL_GPIO_PULL_NO */
-    LL_GPIO_SetPinPull(GPIOA, LL_GPIO_PIN_5, LL_GPIO_PULL_UP);
+    LL_GPIO_SetPinPull(TEST_GPIO_PORT, TEST_LL_GPIO_PIN, LL_GPIO_PULL_UP);
 #endif
 
-#define DELAY_NS 19
+#define DELAY_NS 16
 
     // Precalculate NsToTicks
     uint32_t ticks __attribute__((unused)) = System::NsToTicks(DELAY_NS);
@@ -55,20 +59,20 @@ int main(void)
     {
 
 #if defined(USE_HAL)
-        HAL_GPIO_WritePin(GPIOA, GPIO_PIN_5, GPIO_PIN_SET);
+        HAL_GPIO_WritePin(TEST_GPIO_PORT, TEST_GPIO_PIN, GPIO_PIN_SET);
 #else
-        // LL_GPIO_SetOutputPin(GPIOA, LL_GPIO_PIN_5);
-        WRITE_REG(GPIOA->BSRR, LL_GPIO_PIN_5);
+        // LL_GPIO_SetOutputPin(TEST_GPIO_PORT, TEST_LL_GPIO_PIN);
+        WRITE_REG(TEST_GPIO_PORT->BSRR, TEST_LL_GPIO_PIN);
 #endif
         // Wait (ticks) DWT ticks
         System::DelayTicks(ticks);
         // delayNanos(DELAY_NS);
 
 #if defined(USE_HAL)
-        HAL_GPIO_WritePin(GPIOA, GPIO_PIN_5, GPIO_PIN_RESET);
+        HAL_GPIO_WritePin(TEST_GPIO_PORT, TEST_GPIO_PIN, GPIO_PIN_RESET);
 #else
-        // LL_GPIO_ResetOutputPin(GPIOA, LL_GPIO_PIN_5);
-        WRITE_REG(GPIOA->BSRR, LL_GPIO_PIN_5 << 16U);
+        // LL_GPIO_ResetOutputPin(TEST_GPIO_PORT, TEST_LL_GPIO_PIN);
+        WRITE_REG(TEST_GPIO_PORT->BSRR, TEST_LL_GPIO_PIN << 16U);
 #endif
         // Wait (ticks) DWT ticks
         System::DelayTicks(ticks);

--- a/examples/DWT/DWT.cpp
+++ b/examples/DWT/DWT.cpp
@@ -71,7 +71,8 @@ int main(void)
 #if defined(USE_INAV_DELAY)
         delayNanos(DELAY_NS);
 #else
-        System::DelayTicks(ticks);
+        // System::DelayTicks(ticks);
+        DELAY_TICKS(12);
 #endif /* USE_INAV_DELAY */
 
 #if defined(USE_HAL)
@@ -85,7 +86,8 @@ int main(void)
 #if defined(USE_INAV_DELAY)
         delayNanos(DELAY_NS);
 #else
-        System::DelayTicks(ticks);
+        // System::DelayTicks(ticks);
+        DELAY_TICKS(12);
 #endif /* USE_INAV_DELAY */
 
     }

--- a/examples/DWT/DWT.cpp
+++ b/examples/DWT/DWT.cpp
@@ -6,6 +6,7 @@ using namespace uvos;
 
 // Declare a UVOSboard object called hardware
 UVOSboard hardware;
+UartHandler uart;
 
 int main(void)
 {
@@ -40,7 +41,16 @@ int main(void)
         // Use Toggle to change test pin state
         my_pin.Toggle();
 
+        // Precalculate CyclesPerUs
+        uint32_t cycles_per_us = System::CyclesPerUs();
+
+        // Print cycles_per_us to UART using snprintf to first build a formatted string
+        // and then print it to the UART.
+        char buffer[64];
+        snprintf(buffer, sizeof(buffer), "Cycles per us: %lu\n", cycles_per_us);
+
         // Wait 500ms
-        System::DelayUs(500'000);
+        // System::DelayUs(500'000);
+        System::DelayNs(500, cycles_per_us);
     }
 }

--- a/examples/DWT/DWT.cpp
+++ b/examples/DWT/DWT.cpp
@@ -3,7 +3,9 @@
 #include "stm32h7xx_ll_gpio.h"
 #include "stm32h7xx_ll_bus.h"
 
-// #define USE_HAL
+// #define USE_INAV_DELAY
+// #define USE_HAL /* Uncomment to use ST HAL gpio vs LL/CMSIS
+
 #define TEST_RCC_GPIO_CLOCK_ENABLE() __HAL_RCC_GPIOA_CLK_ENABLE()
 #define TEST_GPIO_PORT GPIOA
 #define TEST_GPIO_PIN GPIO_PIN_5
@@ -63,20 +65,28 @@ int main(void)
 #else
         // LL_GPIO_SetOutputPin(TEST_GPIO_PORT, TEST_LL_GPIO_PIN);
         WRITE_REG(TEST_GPIO_PORT->BSRR, TEST_LL_GPIO_PIN);
-#endif
+#endif /* USE_HAL */
+
         // Wait (ticks) DWT ticks
+#if defined(USE_INAV_DELAY)
+        delayNanos(DELAY_NS);
+#else
         System::DelayTicks(ticks);
-        // delayNanos(DELAY_NS);
+#endif /* USE_INAV_DELAY */
 
 #if defined(USE_HAL)
         HAL_GPIO_WritePin(TEST_GPIO_PORT, TEST_GPIO_PIN, GPIO_PIN_RESET);
 #else
         // LL_GPIO_ResetOutputPin(TEST_GPIO_PORT, TEST_LL_GPIO_PIN);
         WRITE_REG(TEST_GPIO_PORT->BSRR, TEST_LL_GPIO_PIN << 16U);
-#endif
+#endif /* USE_HAL */
+
         // Wait (ticks) DWT ticks
+#if defined(USE_INAV_DELAY)
+        delayNanos(DELAY_NS);
+#else
         System::DelayTicks(ticks);
-        // delayNanos(DELAY_NS);
+#endif /* USE_INAV_DELAY */
 
     }
 }

--- a/examples/DWT/DWT.cpp
+++ b/examples/DWT/DWT.cpp
@@ -1,5 +1,11 @@
 #include "uvos_brd.h"
+#include "stm32h7xx_hal_gpio.h"
 #include "stm32h7xx_ll_gpio.h"
+#include "stm32h7xx_ll_bus.h"
+
+// #define USE_HAL
+
+extern "C" void delayNanos(int32_t ns);
 
 // Use the uvos namespace to prevent having to type
 // uvos:: before all libuvos functions
@@ -16,24 +22,57 @@ int main(void)
     hardware.Configure();
     hardware.Init();
 
-    // Create a test pin object, init as an output
-    uvs_gpio test_pin;
-    test_pin.pin.port = UVS_GPIOA;
-    test_pin.pin.pin  = 5;
-    test_pin.mode     = UVS_GPIO_MODE_OUTPUT_PP;
-    uvs_gpio_init(&test_pin);
-    uvs_gpio_write(&test_pin, 0);
+    /* Enable the GPIO Clock */
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+
+#if defined(USE_HAL)
+  GPIO_InitTypeDef  GPIO_InitStruct;
+  // Configure IO in output push-pull mode to drive external pin
+  GPIO_InitStruct.Mode  = GPIO_MODE_OUTPUT_PP;
+  GPIO_InitStruct.Pull  = GPIO_PULLUP;
+  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+
+  GPIO_InitStruct.Pin = GPIO_PIN_5;
+  HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+#else
+    /* Configure IO in output push-pull mode to drive external LED1 */
+    LL_GPIO_SetPinMode(GPIOA, LL_GPIO_PIN_5, LL_GPIO_MODE_OUTPUT);
+    /* Reset value is LL_GPIO_OUTPUT_PUSHPULL */
+    LL_GPIO_SetPinOutputType(GPIOA, LL_GPIO_PIN_5, LL_GPIO_OUTPUT_PUSHPULL);
+    /* Reset value is LL_GPIO_SPEED_FREQ_LOW */
+    LL_GPIO_SetPinSpeed(GPIOA, LL_GPIO_PIN_5, LL_GPIO_SPEED_FREQ_VERY_HIGH);
+    /* Reset value is LL_GPIO_PULL_NO */
+    LL_GPIO_SetPinPull(GPIOA, LL_GPIO_PIN_5, LL_GPIO_PULL_UP);
+#endif
+
+#define DELAY_NS 19
 
     // Precalculate NsToTicks
-    uint32_t ticks = System::NsToTicks(500);
+    uint32_t ticks __attribute__((unused)) = System::NsToTicks(DELAY_NS);
 
     // Loop forever
     for(;;)
     {
-        // LL_GPIO_TogglePin(GPIOA, LL_GPIO_PIN_5);
-        WRITE_REG(GPIOA->ODR, READ_REG(GPIOA->ODR) ^ LL_GPIO_PIN_5);
 
+#if defined(USE_HAL)
+        HAL_GPIO_WritePin(GPIOA, GPIO_PIN_5, GPIO_PIN_SET);
+#else
+        // LL_GPIO_SetOutputPin(GPIOA, LL_GPIO_PIN_5);
+        WRITE_REG(GPIOA->BSRR, LL_GPIO_PIN_5);
+#endif
         // Wait (ticks) DWT ticks
         System::DelayTicks(ticks);
+        // delayNanos(DELAY_NS);
+
+#if defined(USE_HAL)
+        HAL_GPIO_WritePin(GPIOA, GPIO_PIN_5, GPIO_PIN_RESET);
+#else
+        // LL_GPIO_ResetOutputPin(GPIOA, LL_GPIO_PIN_5);
+        WRITE_REG(GPIOA->BSRR, LL_GPIO_PIN_5 << 16U);
+#endif
+        // Wait (ticks) DWT ticks
+        System::DelayTicks(ticks);
+        // delayNanos(DELAY_NS);
+
     }
 }

--- a/examples/DWT/DWT.cpp
+++ b/examples/DWT/DWT.cpp
@@ -40,6 +40,7 @@ int main(void)
 
   GPIO_InitStruct.Pin = TEST_GPIO_PIN;
   HAL_GPIO_Init(TEST_GPIO_PORT, &GPIO_InitStruct);
+  HAL_GPIO_WritePin(TEST_GPIO_PORT, TEST_GPIO_PIN, GPIO_PIN_RESET);
 #else
     /* Configure IO in output push-pull mode to drive external LED1 */
     LL_GPIO_SetPinMode(TEST_GPIO_PORT, TEST_LL_GPIO_PIN, LL_GPIO_MODE_OUTPUT);
@@ -49,9 +50,10 @@ int main(void)
     LL_GPIO_SetPinSpeed(TEST_GPIO_PORT, TEST_LL_GPIO_PIN, LL_GPIO_SPEED_FREQ_VERY_HIGH);
     /* Reset value is LL_GPIO_PULL_NO */
     LL_GPIO_SetPinPull(TEST_GPIO_PORT, TEST_LL_GPIO_PIN, LL_GPIO_PULL_UP);
+    LL_GPIO_ResetOutputPin(TEST_GPIO_PORT, TEST_LL_GPIO_PIN);
 #endif
 
-#define DELAY_NS 16
+#define DELAY_NS 80
 
     // Precalculate NsToTicks
     uint32_t ticks __attribute__((unused)) = System::NsToTicks(DELAY_NS);
@@ -72,7 +74,7 @@ int main(void)
         delayNanos(DELAY_NS);
 #else
         // System::DelayTicks(ticks);
-        DELAY_TICKS(12);
+        DELAY_TICKS(18);
 #endif /* USE_INAV_DELAY */
 
 #if defined(USE_HAL)
@@ -87,7 +89,7 @@ int main(void)
         delayNanos(DELAY_NS);
 #else
         // System::DelayTicks(ticks);
-        DELAY_TICKS(12);
+        DELAY_TICKS(18);
 #endif /* USE_INAV_DELAY */
 
     }


### PR DESCRIPTION
This pull request includes several changes to the `cores/arduino` library, focusing on enhancing the delay mechanisms and updating pin configurations. The most important changes include the addition of a `DELAY_TICKS` macro, updates to the `System` class methods, and modifications to the `DWT` example.

These changes improve the efficiency and flexibility of delay functions and provide better pin configuration options for USART communication.