### PR TITLE
I2C Peripheral

### DIFF
--- a/cores/arduino/per/i2c.cpp
+++ b/cores/arduino/per/i2c.cpp
@@ -1,0 +1,874 @@
+#include "per/i2c.h"
+#include "sys/system.h"
+#include "util/scopedirqblocker.h"
+extern "C"
+{
+#include "util/hal_map.h"
+}
+
+namespace uvos
+{
+/** Private implementation for I2CHandle */
+class I2CHandle::Impl
+{
+  public:
+    I2CHandle::Result        Init(const I2CHandle::Config& config);
+    const I2CHandle::Config& GetConfig() const { return config_; }
+
+    I2CHandle::Result TransmitBlocking(uint16_t address,
+                                       uint8_t* data,
+                                       uint16_t size,
+                                       uint32_t timeout);
+
+    I2CHandle::Result TransmitDma(uint16_t                       address,
+                                  uint8_t*                       data,
+                                  uint16_t                       size,
+                                  I2CHandle::CallbackFunctionPtr callback,
+                                  void* callback_context);
+
+    I2CHandle::Result ReceiveBlocking(uint16_t address,
+                                      uint8_t* data,
+                                      uint16_t size,
+                                      uint32_t timeout);
+
+    I2CHandle::Result ReceiveDma(uint16_t                       address,
+                                 uint8_t*                       data,
+                                 uint16_t                       size,
+                                 I2CHandle::CallbackFunctionPtr callback,
+                                 void* callback_context);
+
+    I2CHandle::Result ReadDataAtAddress(uint16_t address,
+                                        uint16_t mem_address,
+                                        uint16_t mem_address_size,
+                                        uint8_t* data,
+                                        uint16_t data_size,
+                                        uint32_t timeout);
+
+    I2CHandle::Result WriteDataAtAddress(uint16_t address,
+                                         uint16_t mem_address,
+                                         uint16_t mem_address_size,
+                                         uint8_t* data,
+                                         uint16_t data_size,
+                                         uint32_t timeout);
+
+    // =========================================================
+    // scheduling and global functions
+    struct DmaJob
+    {
+        uint16_t                       slave_address    = 0x10;
+        uint8_t*                       data             = nullptr;
+        uint16_t                       size             = 0;
+        I2CHandle::CallbackFunctionPtr callback         = nullptr;
+        void*                          callback_context = nullptr;
+        I2CHandle::Direction direction = I2CHandle::Direction::TRANSMIT;
+
+        bool IsValidJob() const { return data != nullptr; }
+        void Invalidate() { data = nullptr; }
+    };
+    static void GlobalInit();
+    static bool IsDmaActive();
+    static bool IsDmaTransferQueuedFor(size_t i2c_peripheral_idx);
+    static void QueueDmaTransfer(size_t i2c_peripheral_idx, const DmaJob& job);
+    static void DmaTransferFinished(I2C_HandleTypeDef* hal_i2c_handle,
+                                    I2CHandle::Result  result);
+
+    static constexpr uint8_t              kNumI2CWithDma = 3;
+    static volatile int8_t                dma_active_peripheral_;
+    static DmaJob                         queued_dma_transfers_[kNumI2CWithDma];
+    static I2CHandle::CallbackFunctionPtr next_callback_;
+    static void*                          next_callback_context_;
+
+    // =========================================================
+    // pivate functions and member variables
+    I2CHandle::Config config_;
+    DMA_HandleTypeDef i2c_dma_tc_handle_;
+    I2C_HandleTypeDef i2c_hal_handle_;
+
+    I2CHandle::Result
+    StartDmaTransmission(uint16_t                       address,
+                         uint8_t*                       data,
+                         uint16_t                       size,
+                         I2CHandle::CallbackFunctionPtr callback,
+                         void*                          callback_context);
+
+    I2CHandle::Result StartDmaReception(uint16_t                       address,
+                                        uint8_t*                       data,
+                                        uint16_t                       size,
+                                        I2CHandle::CallbackFunctionPtr callback,
+                                        void* callback_context);
+
+    void InitPins();
+    void DeinitPins();
+};
+
+// ======================================================================
+// Error handler
+// ======================================================================
+
+static void Error_Handler()
+{
+    asm("bkpt 255");
+    while(1) {}
+}
+
+// ================================================================
+// Global references for the availabel I2CHandle::Impls
+// ================================================================
+
+static I2CHandle::Impl i2c_handles[4];
+
+// ================================================================
+// Scheduling and global functions
+// ================================================================
+
+void I2CHandle::Impl::GlobalInit()
+{
+    // init the scheduler queue
+    dma_active_peripheral_ = -1;
+    for(int per = 0; per < kNumI2CWithDma; per++)
+        queued_dma_transfers_[per] = I2CHandle::Impl::DmaJob();
+}
+
+bool I2CHandle::Impl::IsDmaActive()
+{
+    return dma_active_peripheral_ >= 0;
+}
+
+bool I2CHandle::Impl::IsDmaTransferQueuedFor(size_t i2c_peripheral_idx)
+{
+    return queued_dma_transfers_[i2c_peripheral_idx].IsValidJob();
+}
+
+void I2CHandle::Impl::QueueDmaTransfer(size_t i2c_peripheral_idx,
+                                       const I2CHandle::Impl::DmaJob& job)
+{
+    // wait for any previous job on this peripheral to finish
+    // and the queue position to bevome free
+    while(IsDmaTransferQueuedFor(i2c_peripheral_idx)) {};
+
+    // queue the job
+    ScopedIrqBlocker block;
+    queued_dma_transfers_[i2c_peripheral_idx] = job;
+}
+
+void I2CHandle::Impl::DmaTransferFinished(I2C_HandleTypeDef* hal_i2c_handle,
+                                          I2CHandle::Result  result)
+{
+    ScopedIrqBlocker block;
+
+    // on an error, reinit the peripheral to clear any flags
+    if(result != I2CHandle::Result::OK)
+        HAL_I2C_Init(hal_i2c_handle);
+
+    dma_active_peripheral_ = -1;
+
+    if(next_callback_ != nullptr)
+    {
+        // the callback may setup another transmission, hence we shouldn't reset this to
+        // nullptr after the callback - it might overwrite the new transmission.
+        auto callback  = next_callback_;
+        next_callback_ = nullptr;
+        // make the callback
+        callback(next_callback_context_, result);
+    }
+
+    // the callback could have started a new transmission right away...
+    if(IsDmaActive())
+        return;
+
+    // dma is still idle. Check if another i2c peripheral waits for a job.
+    for(int per = 0; per < kNumI2CWithDma; per++)
+        if(IsDmaTransferQueuedFor(per))
+        {
+            I2CHandle::Result result;
+            if(queued_dma_transfers_[per].direction
+               == I2CHandle::Direction::TRANSMIT)
+            {
+                result = i2c_handles[per].StartDmaTransmission(
+                    queued_dma_transfers_[per].slave_address,
+                    queued_dma_transfers_[per].data,
+                    queued_dma_transfers_[per].size,
+                    queued_dma_transfers_[per].callback,
+                    queued_dma_transfers_[per].callback_context);
+            }
+            else
+            {
+                result = i2c_handles[per].StartDmaReception(
+                    queued_dma_transfers_[per].slave_address,
+                    queued_dma_transfers_[per].data,
+                    queued_dma_transfers_[per].size,
+                    queued_dma_transfers_[per].callback,
+                    queued_dma_transfers_[per].callback_context);
+            }
+            if(result == I2CHandle::Result::OK)
+            {
+                // remove the job from the queue
+                queued_dma_transfers_[per].Invalidate();
+                return;
+            }
+        }
+}
+
+// ================================================================
+// I2C functions
+// ================================================================
+
+I2CHandle::Result I2CHandle::Impl::Init(const I2CHandle::Config& config)
+{
+    const int i2cIdx = int(config.periph);
+
+    if(i2cIdx >= 4)
+        return I2CHandle::Result::ERR;
+    if(config.mode != I2CHandle::Config::Mode::I2C_MASTER
+       && config.mode != I2CHandle::Config::Mode::I2C_SLAVE)
+        return I2CHandle::Result::ERR;
+    // Ensuring address is valid and not using reserved addresses
+    if(config.mode == I2CHandle::Config::Mode::I2C_SLAVE
+       && (config.address > 127 || config.address < 16 || config.address > 119))
+        return I2CHandle::Result::ERR;
+
+    config_ = config;
+    constexpr I2C_TypeDef* instances[4]
+        = {I2C1, I2C2, I2C3, I2C4}; // map HAL instances
+    i2c_hal_handle_.Instance = instances[i2cIdx];
+
+    // Set Generic Parameters
+    // Configure Speed
+    // TODO: Make this check the actual I2C clock source instead of it
+    //      "knowing" that it's the PCLK1
+    switch(config_.speed)
+    {
+        case I2CHandle::Config::Speed::I2C_100KHZ:
+            if(System::GetPClk1Freq() == 120000000)
+                // Measured at 100kHz w/ 4k7 pullup
+                i2c_hal_handle_.Init.Timing = 0x6090435F;
+            else
+                // Measured at 100kHz w/ 4k7 pullup
+                i2c_hal_handle_.Init.Timing = 0x30E0628A;
+            break;
+        case I2CHandle::Config::Speed::I2C_400KHZ:
+            if(System::GetPClk1Freq() == 120000000)
+                // Measured at 400kHz w/ 4k7 pullup
+                i2c_hal_handle_.Init.Timing = 0x30B00F2D;
+            else
+                // Measured at 400kHz w/ 4k7 pullup
+                i2c_hal_handle_.Init.Timing = 0x20D01132;
+            break;
+        case I2CHandle::Config::Speed::I2C_1MHZ:
+            if(System::GetPClk1Freq() == 120000000)
+                // Measured at 837kHz w/ 4k7 pullup
+                i2c_hal_handle_.Init.Timing = 0x10A00B20;
+            else
+                // Measured at 862kHz w/ 4k7 pullup
+                i2c_hal_handle_.Init.Timing = 0x1080091A;
+            break;
+        default: break;
+    }
+
+    // HAL expects the address to be represented in its I2C
+    // format, i.e. shifted to the left by one, since bit 0
+    // indicated whether the transmission is a read or write
+    i2c_hal_handle_.Init.OwnAddress1      = config.address << 1;
+    i2c_hal_handle_.Init.AddressingMode   = I2C_ADDRESSINGMODE_7BIT;
+    i2c_hal_handle_.Init.DualAddressMode  = I2C_DUALADDRESS_DISABLE;
+    i2c_hal_handle_.Init.OwnAddress2      = 0;
+    i2c_hal_handle_.Init.OwnAddress2Masks = I2C_OA2_NOMASK;
+    i2c_hal_handle_.Init.GeneralCallMode  = I2C_GENERALCALL_DISABLE;
+    i2c_hal_handle_.Init.NoStretchMode    = I2C_NOSTRETCH_DISABLE;
+    if(HAL_I2C_Init(&i2c_hal_handle_) != HAL_OK)
+        return I2CHandle::Result::ERR;
+    if(HAL_I2CEx_ConfigAnalogFilter(&i2c_hal_handle_, I2C_ANALOGFILTER_ENABLE)
+       != HAL_OK)
+        return I2CHandle::Result::ERR;
+    if(HAL_I2CEx_ConfigDigitalFilter(&i2c_hal_handle_, 0) != HAL_OK)
+        return I2CHandle::Result::ERR;
+
+    return I2CHandle::Result::OK;
+}
+
+I2CHandle::Result I2CHandle::Impl::TransmitBlocking(uint16_t address,
+                                                    uint8_t* data,
+                                                    uint16_t size,
+                                                    uint32_t timeout)
+{
+    // wait for previous transfer to be finished
+    while(HAL_I2C_GetState(&i2c_hal_handle_) != HAL_I2C_STATE_READY) {};
+
+    HAL_StatusTypeDef status;
+    if(config_.mode == I2CHandle::Config::Mode::I2C_MASTER)
+    {
+        status = HAL_I2C_Master_Transmit(
+            &i2c_hal_handle_, address << 1, data, size, timeout);
+    }
+    else
+    {
+        status = HAL_I2C_Slave_Transmit(&i2c_hal_handle_, data, size, timeout);
+    }
+    if(status != HAL_OK)
+        return I2CHandle::Result::ERR;
+
+    return I2CHandle::Result::OK;
+}
+
+I2CHandle::Result
+I2CHandle::Impl::TransmitDma(uint16_t                       address,
+                             uint8_t*                       data,
+                             uint16_t                       size,
+                             I2CHandle::CallbackFunctionPtr callback,
+                             void*                          callback_context)
+{
+    // I2C4 has no DMA yet.
+    if(config_.periph == I2CHandle::Config::Peripheral::I2C_4)
+        return I2CHandle::Result::ERR;
+
+    const int i2cIdx = int(config_.periph);
+
+    I2CHandle::Direction direction = I2CHandle::Direction::TRANSMIT;
+
+    // if dma is currently running - queue a job
+    if(IsDmaActive())
+    {
+        DmaJob job;
+        job.slave_address    = address;
+        job.data             = data;
+        job.size             = size;
+        job.direction        = direction;
+        job.callback         = callback;
+        job.callback_context = callback_context;
+        // queue a job (blocks until the queue position is free)
+        QueueDmaTransfer(i2cIdx, job);
+        // TODO: the user can't tell if he got returned "OK"
+        // because the transfer was executed or because it was queued...
+        // should we change that?
+        return I2CHandle::Result::OK;
+    }
+    else
+        // start transmission right away
+        return StartDmaTransmission(
+            address, data, size, callback, callback_context);
+}
+
+I2CHandle::Result I2CHandle::Impl::ReceiveBlocking(uint16_t address,
+                                                   uint8_t* data,
+                                                   uint16_t size,
+                                                   uint32_t timeout)
+{
+    // wait for previous transfer to be finished
+    while(HAL_I2C_GetState(&i2c_hal_handle_) != HAL_I2C_STATE_READY) {};
+
+    HAL_StatusTypeDef status;
+    if(config_.mode == I2CHandle::Config::Mode::I2C_MASTER)
+    {
+        status = HAL_I2C_Master_Receive(
+            &i2c_hal_handle_, address << 1, data, size, timeout);
+    }
+    else
+        status = HAL_I2C_Slave_Receive(&i2c_hal_handle_, data, size, timeout);
+
+    if(status != HAL_OK)
+        return I2CHandle::Result::ERR;
+
+    return I2CHandle::Result::OK;
+}
+
+I2CHandle::Result
+I2CHandle::Impl::ReceiveDma(uint16_t                       address,
+                            uint8_t*                       data,
+                            uint16_t                       size,
+                            I2CHandle::CallbackFunctionPtr callback,
+                            void*                          callback_context)
+{
+    // I2C4 has no DMA yet.
+    if(config_.periph == I2CHandle::Config::Peripheral::I2C_4)
+        return I2CHandle::Result::ERR;
+
+    const int i2cIdx = int(config_.periph);
+
+    I2CHandle::Direction direction = I2CHandle::Direction::RECEIVE;
+
+    // if dma is currently running - queue a job
+    if(IsDmaActive())
+    {
+        DmaJob job;
+        job.slave_address    = address;
+        job.data             = data;
+        job.size             = size;
+        job.direction        = direction;
+        job.callback         = callback;
+        job.callback_context = callback_context;
+        // queue a job (blocks until the queue position is free)
+        QueueDmaTransfer(i2cIdx, job);
+        // TODO: the user can't tell if he got returned "OK"
+        // because the transfer was executed or because it was queued...
+        // should we change that?
+        return I2CHandle::Result::OK;
+    }
+    else
+        // start reception right away
+        return StartDmaReception(
+            address, data, size, callback, callback_context);
+}
+
+I2CHandle::Result I2CHandle::Impl::ReadDataAtAddress(uint16_t address,
+                                                     uint16_t mem_address,
+                                                     uint16_t mem_address_size,
+                                                     uint8_t* data,
+                                                     uint16_t data_size,
+                                                     uint32_t timeout)
+{
+    // Only master devices can make requests
+    if(config_.mode != I2CHandle::Config::Mode::I2C_MASTER)
+        return I2CHandle::Result::ERR;
+
+    // wait for previous transfer to be finished
+    while(HAL_I2C_GetState(&i2c_hal_handle_) != HAL_I2C_STATE_READY) {};
+    if(HAL_I2C_Mem_Read(&i2c_hal_handle_,
+                        address,
+                        mem_address,
+                        mem_address_size,
+                        data,
+                        data_size,
+                        timeout)
+       != HAL_OK)
+    {
+        return I2CHandle::Result::ERR;
+    }
+    return I2CHandle::Result::OK;
+}
+
+I2CHandle::Result I2CHandle::Impl::WriteDataAtAddress(uint16_t address,
+                                                      uint16_t mem_address,
+                                                      uint16_t mem_address_size,
+                                                      uint8_t* data,
+                                                      uint16_t data_size,
+                                                      uint32_t timeout)
+{
+    // Only master devices can make requests
+    if(config_.mode != I2CHandle::Config::Mode::I2C_MASTER)
+        return I2CHandle::Result::ERR;
+
+    // wait for previous transfer to be finished
+    while(HAL_I2C_GetState(&i2c_hal_handle_) != HAL_I2C_STATE_READY) {};
+    if(HAL_I2C_Mem_Write(&i2c_hal_handle_,
+                         address,
+                         mem_address,
+                         mem_address_size,
+                         data,
+                         data_size,
+                         timeout)
+       != HAL_OK)
+    {
+        return I2CHandle::Result::ERR;
+    }
+    return I2CHandle::Result::OK;
+}
+
+I2CHandle::Result
+I2CHandle::Impl::StartDmaTransmission(uint16_t                       address,
+                                      uint8_t*                       data,
+                                      uint16_t                       size,
+                                      I2CHandle::CallbackFunctionPtr callback,
+                                      void* callback_context)
+{
+    // this could be called from both the scheduler ISR
+    // and from user code via uvs_i2c_transmit_dma()
+    // TODO: Add some sort of locking mechanism.
+
+    // wait for previous transfer to be finished
+    while(HAL_I2C_GetState(&i2c_hal_handle_) != HAL_I2C_STATE_READY) {};
+
+    // reinit the DMA
+    i2c_dma_tc_handle_.Instance = DMA1_Stream6;
+    switch(config_.periph)
+    {
+        case I2CHandle::Config::Peripheral::I2C_1:
+            i2c_dma_tc_handle_.Init.Request = DMA_REQUEST_I2C1_TX;
+            break;
+        case I2CHandle::Config::Peripheral::I2C_2:
+            i2c_dma_tc_handle_.Init.Request = DMA_REQUEST_I2C2_TX;
+            break;
+        case I2CHandle::Config::Peripheral::I2C_3:
+            i2c_dma_tc_handle_.Init.Request = DMA_REQUEST_I2C3_TX;
+            break;
+        // I2C4 has no DMA yet. TODO
+        default: return I2CHandle::Result::ERR;
+    }
+    i2c_dma_tc_handle_.Init.Direction           = DMA_MEMORY_TO_PERIPH;
+    i2c_dma_tc_handle_.Init.PeriphInc           = DMA_PINC_DISABLE;
+    i2c_dma_tc_handle_.Init.MemInc              = DMA_MINC_ENABLE;
+    i2c_dma_tc_handle_.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
+    i2c_dma_tc_handle_.Init.MemDataAlignment    = DMA_MDATAALIGN_BYTE;
+    i2c_dma_tc_handle_.Init.Mode                = DMA_NORMAL;
+    i2c_dma_tc_handle_.Init.Priority            = DMA_PRIORITY_LOW;
+    i2c_dma_tc_handle_.Init.FIFOMode            = DMA_FIFOMODE_DISABLE;
+    i2c_dma_tc_handle_.Init.MemBurst            = DMA_MBURST_SINGLE;
+    i2c_dma_tc_handle_.Init.PeriphBurst         = DMA_PBURST_SINGLE;
+
+    if(HAL_DMA_Init(&i2c_dma_tc_handle_) != HAL_OK)
+    {
+        Error_Handler();
+    }
+
+    __HAL_LINKDMA(&i2c_hal_handle_, hdmatx, i2c_dma_tc_handle_);
+
+    // start the transfer and block irq until return
+    ScopedIrqBlocker block;
+
+    dma_active_peripheral_ = int(config_.periph);
+    next_callback_         = callback;
+    next_callback_context_ = callback_context;
+
+    HAL_StatusTypeDef status;
+    if(config_.mode == I2CHandle::Config::Mode::I2C_MASTER)
+    {
+        status = HAL_I2C_Master_Transmit_DMA(
+            &i2c_hal_handle_, address << 1, data, size);
+    }
+    else
+    {
+        status = HAL_I2C_Slave_Transmit_DMA(&i2c_hal_handle_, data, size);
+    }
+
+    if(status != HAL_OK)
+    {
+        dma_active_peripheral_ = -1;
+        next_callback_         = NULL;
+        next_callback_context_ = NULL;
+        return I2CHandle::Result::ERR;
+    }
+    return I2CHandle::Result::OK;
+}
+
+I2CHandle::Result
+I2CHandle::Impl::StartDmaReception(uint16_t                       address,
+                                   uint8_t*                       data,
+                                   uint16_t                       size,
+                                   I2CHandle::CallbackFunctionPtr callback,
+                                   void* callback_context)
+{
+    // wait for previous transfer to be finished
+    while(HAL_I2C_GetState(&i2c_hal_handle_) != HAL_I2C_STATE_READY) {};
+
+    // reinit the DMA
+    i2c_dma_tc_handle_.Instance = DMA1_Stream6;
+    switch(config_.periph)
+    {
+        case I2CHandle::Config::Peripheral::I2C_1:
+            i2c_dma_tc_handle_.Init.Request = DMA_REQUEST_I2C1_RX;
+            break;
+        case I2CHandle::Config::Peripheral::I2C_2:
+            i2c_dma_tc_handle_.Init.Request = DMA_REQUEST_I2C2_RX;
+            break;
+        case I2CHandle::Config::Peripheral::I2C_3:
+            i2c_dma_tc_handle_.Init.Request = DMA_REQUEST_I2C3_RX;
+            break;
+        // I2C4 has no DMA yet. TODO
+        default: return I2CHandle::Result::ERR;
+    }
+    i2c_dma_tc_handle_.Init.Direction           = DMA_PERIPH_TO_MEMORY;
+    i2c_dma_tc_handle_.Init.PeriphInc           = DMA_PINC_DISABLE;
+    i2c_dma_tc_handle_.Init.MemInc              = DMA_MINC_ENABLE;
+    i2c_dma_tc_handle_.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
+    i2c_dma_tc_handle_.Init.MemDataAlignment    = DMA_MDATAALIGN_BYTE;
+    i2c_dma_tc_handle_.Init.Mode                = DMA_NORMAL;
+    i2c_dma_tc_handle_.Init.Priority            = DMA_PRIORITY_LOW;
+    i2c_dma_tc_handle_.Init.FIFOMode            = DMA_FIFOMODE_DISABLE;
+    i2c_dma_tc_handle_.Init.MemBurst            = DMA_MBURST_SINGLE;
+    i2c_dma_tc_handle_.Init.PeriphBurst         = DMA_PBURST_SINGLE;
+
+    if(HAL_DMA_Init(&i2c_dma_tc_handle_) != HAL_OK)
+    {
+        Error_Handler();
+    }
+
+    __HAL_LINKDMA(&i2c_hal_handle_, hdmarx, i2c_dma_tc_handle_);
+
+    // start the transfer and block irq until return
+    ScopedIrqBlocker block;
+
+    dma_active_peripheral_ = int(config_.periph);
+    next_callback_         = callback;
+    next_callback_context_ = callback_context;
+
+    HAL_StatusTypeDef status;
+    if(config_.mode == I2CHandle::Config::Mode::I2C_MASTER)
+    {
+        status = HAL_I2C_Master_Receive_DMA(
+            &i2c_hal_handle_, address << 1, data, size);
+    }
+    else
+    {
+        status = HAL_I2C_Slave_Receive_DMA(&i2c_hal_handle_, data, size);
+    }
+
+    if(status != HAL_OK)
+    {
+        dma_active_peripheral_ = -1;
+        next_callback_         = NULL;
+        next_callback_context_ = NULL;
+        return I2CHandle::Result::ERR;
+    }
+    return I2CHandle::Result::OK;
+}
+
+void I2CHandle::Impl::InitPins()
+{
+    GPIO_InitTypeDef GPIO_InitStruct;
+    GPIO_TypeDef*    port;
+
+    GPIO_InitStruct.Mode  = GPIO_MODE_AF_OD;
+    GPIO_InitStruct.Pull  = GPIO_NOPULL;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    switch(config_.periph)
+    {
+        case I2CHandle::Config::Peripheral::I2C_1:
+            GPIO_InitStruct.Alternate = GPIO_AF4_I2C1;
+            break;
+        case I2CHandle::Config::Peripheral::I2C_2:
+            GPIO_InitStruct.Alternate = GPIO_AF4_I2C2;
+            break;
+        case I2CHandle::Config::Peripheral::I2C_3:
+            GPIO_InitStruct.Alternate = GPIO_AF4_I2C3;
+            break;
+        case I2CHandle::Config::Peripheral::I2C_4:
+            GPIO_InitStruct.Alternate = GPIO_AF4_I2C4;
+            break;
+        default: break;
+    }
+
+    port                = uvs_hal_map_get_port(&config_.pin_config.scl);
+    GPIO_InitStruct.Pin = uvs_hal_map_get_pin(&config_.pin_config.scl);
+    HAL_GPIO_Init(port, &GPIO_InitStruct);
+    port                = uvs_hal_map_get_port(&config_.pin_config.sda);
+    GPIO_InitStruct.Pin = uvs_hal_map_get_pin(&config_.pin_config.sda);
+    HAL_GPIO_Init(port, &GPIO_InitStruct);
+}
+
+void I2CHandle::Impl::DeinitPins()
+{
+    GPIO_TypeDef* port;
+    uint16_t      pin;
+    port = uvs_hal_map_get_port(&config_.pin_config.scl);
+    pin  = uvs_hal_map_get_pin(&config_.pin_config.scl);
+    HAL_GPIO_DeInit(port, pin);
+    port = uvs_hal_map_get_port(&config_.pin_config.sda);
+    pin  = uvs_hal_map_get_pin(&config_.pin_config.sda);
+    HAL_GPIO_DeInit(port, pin);
+}
+
+volatile int8_t         I2CHandle::Impl::dma_active_peripheral_;
+I2CHandle::Impl::DmaJob I2CHandle::Impl::queued_dma_transfers_[kNumI2CWithDma];
+I2CHandle::CallbackFunctionPtr I2CHandle::Impl::next_callback_;
+void*                          I2CHandle::Impl::next_callback_context_;
+
+// ======================================================================
+// HAL service functions
+// ======================================================================
+
+extern "C" void HAL_I2C_MspInit(I2C_HandleTypeDef* i2c_handle)
+{
+    if(i2c_handle->Instance == I2C1)
+    {
+        __HAL_RCC_GPIOB_CLK_ENABLE();
+        i2c_handles[0].InitPins();
+        __HAL_RCC_I2C1_CLK_ENABLE();
+        __HAL_RCC_DMA1_CLK_ENABLE();
+
+        HAL_NVIC_SetPriority(I2C1_EV_IRQn, 0, 0);
+        HAL_NVIC_EnableIRQ(I2C1_EV_IRQn);
+    }
+    else if(i2c_handle->Instance == I2C2)
+    {
+        __HAL_RCC_GPIOH_CLK_ENABLE();
+        __HAL_RCC_GPIOB_CLK_ENABLE();
+        i2c_handles[1].InitPins();
+        __HAL_RCC_I2C2_CLK_ENABLE();
+        __HAL_RCC_DMA1_CLK_ENABLE();
+
+        HAL_NVIC_SetPriority(I2C2_EV_IRQn, 0, 0);
+        HAL_NVIC_EnableIRQ(I2C2_EV_IRQn);
+    }
+    else if(i2c_handle->Instance == I2C3)
+    {
+        // Enable RCC GPIO CLK for necessary ports.
+        i2c_handles[2].InitPins();
+        __HAL_RCC_I2C3_CLK_ENABLE();
+        __HAL_RCC_DMA1_CLK_ENABLE();
+
+        HAL_NVIC_SetPriority(I2C3_EV_IRQn, 0, 0);
+        HAL_NVIC_EnableIRQ(I2C3_EV_IRQn);
+    }
+    else if(i2c_handle->Instance == I2C4)
+    {
+        __HAL_RCC_GPIOB_CLK_ENABLE();
+        i2c_handles[3].InitPins();
+        __HAL_RCC_I2C4_CLK_ENABLE();
+
+        // I2C4 needs BMDA
+        // TODO
+    }
+}
+
+extern "C" void HAL_I2C_MspDeInit(I2C_HandleTypeDef* i2c_handle)
+{
+    if(i2c_handle->Instance == I2C1)
+    {
+        __HAL_RCC_I2C1_CLK_DISABLE();
+        i2c_handles[0].DeinitPins();
+    }
+    else if(i2c_handle->Instance == I2C2)
+    {
+        __HAL_RCC_I2C2_CLK_DISABLE();
+        i2c_handles[1].DeinitPins();
+    }
+    else if(i2c_handle->Instance == I2C3)
+    {
+        // Enable RCC GPIO CLK for necessary ports.
+        __HAL_RCC_I2C3_CLK_DISABLE();
+        i2c_handles[2].DeinitPins();
+    }
+    else if(i2c_handle->Instance == I2C4)
+    {
+        __HAL_RCC_I2C4_CLK_DISABLE();
+        i2c_handles[3].DeinitPins();
+    }
+}
+
+extern "C" void uvs_i2c_global_init()
+{
+    I2CHandle::Impl::GlobalInit();
+}
+
+// ======================================================================
+// ISRs and event handlers
+// ======================================================================
+
+// we need this intermediary function to be able to call into
+// private functions of the I2CHandle objects...
+void halI2CDmaStreamCallback(void)
+{
+    ScopedIrqBlocker block;
+    if(I2CHandle::Impl::dma_active_peripheral_ >= 0)
+        HAL_DMA_IRQHandler(&i2c_handles[I2CHandle::Impl::dma_active_peripheral_]
+                                .i2c_dma_tc_handle_);
+}
+extern "C" void DMA1_Stream6_IRQHandler(void)
+{
+    halI2CDmaStreamCallback();
+}
+
+extern "C" void I2C1_EV_IRQHandler()
+{
+    HAL_I2C_EV_IRQHandler(&i2c_handles[0].i2c_hal_handle_);
+}
+
+extern "C" void I2C2_EV_IRQHandler()
+{
+    HAL_I2C_EV_IRQHandler(&i2c_handles[1].i2c_hal_handle_);
+}
+
+extern "C" void I2C3_EV_IRQHandler()
+{
+    HAL_I2C_EV_IRQHandler(&i2c_handles[2].i2c_hal_handle_);
+}
+
+extern "C" void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef* i2c_handle)
+{
+    I2CHandle::Impl::DmaTransferFinished(i2c_handle, I2CHandle::Result::OK);
+}
+
+extern "C" void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef* i2c_handle)
+{
+    I2CHandle::Impl::DmaTransferFinished(i2c_handle, I2CHandle::Result::OK);
+}
+
+extern "C" void HAL_I2C_SlaveTxCpltCallback(I2C_HandleTypeDef* i2c_handle)
+{
+    I2CHandle::Impl::DmaTransferFinished(i2c_handle, I2CHandle::Result::OK);
+}
+
+extern "C" void HAL_I2C_SlaveRxCpltCallback(I2C_HandleTypeDef* i2c_handle)
+{
+    I2CHandle::Impl::DmaTransferFinished(i2c_handle, I2CHandle::Result::OK);
+}
+
+extern "C" void HAL_I2C_ErrorCallback(I2C_HandleTypeDef* i2c_handle)
+{
+    I2CHandle::Impl::DmaTransferFinished(i2c_handle, I2CHandle::Result::ERR);
+}
+
+// ======================================================================
+// I2CHandle > I2CHandlePimpl
+// ======================================================================
+
+I2CHandle::Result I2CHandle::Init(const I2CHandle::Config& config)
+{
+    // set the pimpl pointer
+    pimpl_ = &i2c_handles[int(config.periph)];
+    return pimpl_->Init(config);
+}
+
+const I2CHandle::Config& I2CHandle::GetConfig() const
+{
+    return pimpl_->GetConfig();
+}
+
+I2CHandle::Result I2CHandle::TransmitBlocking(uint16_t address,
+                                              uint8_t* data,
+                                              uint16_t size,
+                                              uint32_t timeout)
+{
+    return pimpl_->TransmitBlocking(address, data, size, timeout);
+}
+
+I2CHandle::Result I2CHandle::ReceiveBlocking(uint16_t address,
+                                             uint8_t* data,
+                                             uint16_t size,
+                                             uint32_t timeout)
+{
+    return pimpl_->ReceiveBlocking(address, data, size, timeout);
+}
+
+I2CHandle::Result
+I2CHandle::TransmitDma(uint16_t                       address,
+                       uint8_t*                       data,
+                       uint16_t                       size,
+                       I2CHandle::CallbackFunctionPtr callback,
+                       void*                          callback_context)
+{
+    return pimpl_->TransmitDma(address, data, size, callback, callback_context);
+}
+
+I2CHandle::Result I2CHandle::ReceiveDma(uint16_t                       address,
+                                        uint8_t*                       data,
+                                        uint16_t                       size,
+                                        I2CHandle::CallbackFunctionPtr callback,
+                                        void* callback_context)
+{
+    return pimpl_->ReceiveDma(address, data, size, callback, callback_context);
+}
+
+
+I2CHandle::Result I2CHandle::ReadDataAtAddress(uint16_t address,
+                                               uint16_t mem_address,
+                                               uint16_t mem_address_size,
+                                               uint8_t* data,
+                                               uint16_t data_size,
+                                               uint32_t timeout)
+{
+    return pimpl_->ReadDataAtAddress(
+        address, mem_address, mem_address_size, data, data_size, timeout);
+}
+
+I2CHandle::Result I2CHandle::WriteDataAtAddress(uint16_t address,
+                                                uint16_t mem_address,
+                                                uint16_t mem_address_size,
+                                                uint8_t* data,
+                                                uint16_t data_size,
+                                                uint32_t timeout)
+{
+    return pimpl_->WriteDataAtAddress(
+        address, mem_address, mem_address_size, data, data_size, timeout);
+}
+
+} // namespace uvos

--- a/cores/arduino/per/i2c.cpp
+++ b/cores/arduino/per/i2c.cpp
@@ -298,7 +298,7 @@ I2CHandle::Result I2CHandle::Impl::IsDeviceReady(uint16_t address,
     if(config_.mode != I2CHandle::Config::Mode::I2C_MASTER)
         return I2CHandle::Result::ERR;
 
-    HAL_StatusTypeDef status = HAL_I2C_IsDeviceReady(&i2c_hal_handle_, address << 1, trials, timeout);
+    HAL_StatusTypeDef status = HAL_I2C_IsDeviceReady(&i2c_hal_handle_, address, trials, timeout);
 
     if(status != HAL_OK)
         return I2CHandle::Result::ERR;

--- a/cores/arduino/per/i2c.h
+++ b/cores/arduino/per/i2c.h
@@ -1,0 +1,219 @@
+#pragma once
+
+#include "uvos_core.h"
+
+namespace uvos
+{
+/** A handle for interacting with an I2C peripheral. This is a dumb
+ *  gateway that internally points to one of the four I2C peripherals
+ *  after it was initialised. It can then be copied and passed around.
+ *  Use an I2CHandle like this:
+ *  
+ *      // setup the configuration
+ *      I2CHandle::Config i2c_conf;
+ *      i2c_conf.periph = I2CHandle::Config::Peripheral::I2C_1;
+ *      i2c_conf.speed  = I2CHandle::Config::Speed::I2C_400KHZ;
+ *      i2c_conf.mode   = I2CHandle::Config::Mode::Master;
+ *      i2c_conf.pin_config.scl  = {DSY_GPIOB, 8};
+ *      i2c_conf.pin_config.sda  = {DSY_GPIOB, 9};
+ *      // initialise the peripheral
+ *      I2CHandle i2c;
+ *      i2c.Init(i2c_conf);
+ *      // now i2c points to the corresponding peripheral and can be used.
+ *      i2c.TransmitBlocking( ... );
+ */
+class I2CHandle
+{
+  public:
+    /** Contains settings for initialising an I2C interface. */
+    struct Config
+    {
+        /** Specifies whether the interface will operate in master or slave mode. */
+        enum class Mode
+        {
+            I2C_MASTER,
+            I2C_SLAVE,
+        };
+
+        /** Specifices the internal peripheral to use (these are mapped to different pins on the hardware). */
+        enum class Peripheral
+        {
+            I2C_1 = 0, /**< & */
+            I2C_2,     /**< & */
+            I2C_3,     /**< & */
+            I2C_4,     /**< & */
+        };
+
+        /** Rate at which the clock/data will be sent/received. The device being used will have maximum speeds.
+         *  1MHZ Mode is currently 886kHz
+         */
+        enum class Speed
+        {
+            I2C_100KHZ, /**< & */
+            I2C_400KHZ, /**< & */
+            I2C_1MHZ,   /**< & */
+        };
+
+        Peripheral periph; /**< & */
+        struct
+        {
+            uvs_gpio_pin scl; /**< & */
+            uvs_gpio_pin sda; /**< & */
+        } pin_config;         /**< & */
+
+        Speed speed; /**< & */
+        Mode  mode;  /**< & */
+        // 0x10 is chosen as a default to avoid conflicts with reserved addresses
+        uint8_t address = 0x10; /**< & */
+    };
+
+    /** Return values for I2C functions. */
+    enum class Result
+    {
+        OK, /**< & */
+        ERR /**< & */
+    };
+
+    enum class Direction
+    {
+        TRANSMIT, /**< & */
+        RECEIVE,  /**< & */
+    };
+
+    I2CHandle() : pimpl_(nullptr) {}
+    I2CHandle(const I2CHandle& other) = default;
+    I2CHandle& operator=(const I2CHandle& other) = default;
+
+    /** Initializes an I2C peripheral. */
+    Result Init(const Config& config);
+
+    /** Returns the current config. */
+    const Config& GetConfig() const;
+
+    /** Transmits data and blocks until the transmission is complete.
+     *  Use this for smaller transmissions of a few bytes.
+     * 
+     *  \param address      The slave device address. Unused in slave mode.
+     *  \param data         A pointer to the data to be sent.
+     *  \param size         The size of the data to be sent, in bytes.
+     *  \param timeout      A timeout.
+     */
+    Result TransmitBlocking(uint16_t address,
+                            uint8_t* data,
+                            uint16_t size,
+                            uint32_t timeout);
+
+    /** Receives data and blocks until the reception is complete.
+     *  Use this for smaller transmissions of a few bytes.
+     * 
+     *  \param address      The slave device address. Unused in slave mode.
+     *  \param data         A pointer to the data to be received.
+     *  \param size         The size of the data to be received, in bytes.
+     *  \param timeout      A timeout.
+     */
+    Result ReceiveBlocking(uint16_t address,
+                           uint8_t* data,
+                           uint16_t size,
+                           uint32_t timeout);
+
+    /** A callback to be executed when a dma transfer is complete. */
+    typedef void (*CallbackFunctionPtr)(void* context, Result result);
+
+    /** Transmits data with a DMA and returns immediately. Use this for larger transmissions.
+     *  The pointer to data must be located in the D2 memory domain by adding the 
+     *  `DMA_BUFFER_MEM_SECTION` attribute like this:
+     *      uint8_t DMA_BUFFER_MEM_SECTION my_buffer[100];
+     *  If that is not possible for some reason, you MUST clear the cachelines spanning the size of 
+     *  the buffer, before initiating the dma transfer by calling 
+     *  `uvs_dma_clear_cache_for_buffer(buffer, size);`
+     * 
+     *  A single DMA is shared across I2C1, I2C2 and I2C3. I2C4 has no DMA support (yet).
+     *  If the DMA is busy with another transfer, the job will be queued and executed later.
+     *  If there is a job waiting to be executed for this I2C peripheral, this function
+     *  will block until the queue is free and the job can be queued.
+     * 
+     *  \param address      The slave device address. Unused in slave mode.
+     *  \param data         A pointer to the data to be sent.
+     *  \param size         The size of the data to be sent, in bytes.
+     *  \param callback     A callback to execute when the transfer finishes, or NULL.
+     *  \param callback_context A pointer that will be passed back to you in the callback.      
+     */
+    Result TransmitDma(uint16_t            address,
+                       uint8_t*            data,
+                       uint16_t            size,
+                       CallbackFunctionPtr callback,
+                       void*               callback_context);
+
+    /** Receives data with a DMA and returns immediately. Use this for larger transmissions.
+     *  The pointer to data must be located in the D2 memory domain by adding the 
+     *  `DMA_BUFFER_MEM_SECTION` attribute like this:
+     *      uint8_t DMA_BUFFER_MEM_SECTION my_buffer[100];
+     *  If that is not possible for some reason, you MUST clear the cachelines spanning the size of 
+     *  the buffer, before initiating the dma transfer by calling 
+     *  `uvs_dma_clear_cache_for_buffer(buffer, size);`
+     * 
+     *  A single DMA is shared across I2C, I2C2 and I2C3. I2C4 has no DMA support (yet).
+     *  If the DMA is busy with another transfer, the job will be queued and executed later.
+     *  If there is a job waiting to be executed for this I2C peripheral, this function
+     *  will block until the queue is free and the job can be queued.
+     * 
+     *  \param address      The slave device address. Unused in slave mode.
+     *  \param data         A pointer to the data buffer.
+     *  \param size         The size of the data to be received, in bytes.
+     *  \param callback     A callback to execute when the transfer finishes, or NULL.
+     *  \param callback_context A pointer that will be passed back to you in the callback.      
+     */
+    Result ReceiveDma(uint16_t            address,
+                      uint8_t*            data,
+                      uint16_t            size,
+                      CallbackFunctionPtr callback,
+                      void*               callback_context);
+
+    /** Reads an amount of data from a specific memory address. 
+    *   This method will return an error if the I2C peripheral is in slave mode. 
+    * 
+    * \param address            The slave device address.
+    * \param mem_address        Pointer to data containing the address to read from device.
+    * \param mem_address_size   Size of the memory address in bytes.
+    * \param data               Pointer to buffer that will be filled with contents at mem_address
+    * \param data_size          Size of the data to be read in bytes.
+    * \param timeout            The timeout in milliseconds before returning without communication
+    */
+    Result ReadDataAtAddress(uint16_t address,
+                             uint16_t mem_address,
+                             uint16_t mem_address_size,
+                             uint8_t* data,
+                             uint16_t data_size,
+                             uint32_t timeout);
+
+    /** Writes an amount of data from a specific memory address. 
+    *   This method will return an error if the I2C peripheral is in slave mode. 
+    * 
+    * \param address            The slave device address.
+    * \param mem_address        Pointer to data containing the address to write to device.
+    * \param mem_address_size   Size of the memory address in bytes.
+    * \param data               Pointer to buffer that will be written to the mem_address
+    * \param data_size          Size of the data to be written in bytes.
+    * \param timeout            The timeout in milliseconds before returning without communication
+    */
+    Result WriteDataAtAddress(uint16_t address,
+                              uint16_t mem_address,
+                              uint16_t mem_address_size,
+                              uint8_t* data,
+                              uint16_t data_size,
+                              uint32_t timeout);
+
+
+    class Impl; /**< & */
+
+  private:
+    Impl* pimpl_;
+};
+
+extern "C"
+{
+    /** internal. Used for global init. */
+    void uvs_i2c_global_init();
+};
+
+} // namespace uvos

--- a/cores/arduino/per/i2c.h
+++ b/cores/arduino/per/i2c.h
@@ -90,6 +90,16 @@ class I2CHandle
     /** Returns the current config. */
     const Config& GetConfig() const;
 
+    /** Checks if target device is ready for communication.
+     *  This function will return an error if the I2C peripheral is in slave mode.
+     *  \param address      The slave device address. Unused in slave mode.
+     *  \param trials       Number of trials.
+     *  \param timeout      Timeout duration in milliseconds.
+     */
+    Result IsDeviceReady(uint16_t address,
+                         uint32_t trials,
+                         uint32_t timeout);
+
     /** Transmits data and blocks until the transmission is complete.
      *  Use this for smaller transmissions of a few bytes.
      * 

--- a/cores/arduino/stm32/HAL/stm32yyxx_hal_i2c.c
+++ b/cores/arduino/stm32/HAL/stm32yyxx_hal_i2c.c
@@ -1,0 +1,42 @@
+/* HAL raised several warnings, ignore them */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
+#ifdef STM32C0xx
+  #include "stm32c0xx_hal_i2c.c"
+#elif STM32F0xx
+  #include "stm32f0xx_hal_i2c.c"
+#elif STM32F1xx
+  #include "stm32f1xx_hal_i2c.c"
+#elif STM32F2xx
+  #include "stm32f2xx_hal_i2c.c"
+#elif STM32F3xx
+  #include "stm32f3xx_hal_i2c.c"
+#elif STM32F4xx
+  #include "stm32f4xx_hal_i2c.c"
+#elif STM32F7xx
+  #include "stm32f7xx_hal_i2c.c"
+#elif STM32G0xx
+  #include "stm32g0xx_hal_i2c.c"
+#elif STM32G4xx
+  #include "stm32g4xx_hal_i2c.c"
+#elif STM32H7xx
+  #include "stm32h7xx_hal_i2c.c"
+#elif STM32L0xx
+  #include "stm32l0xx_hal_i2c.c"
+#elif STM32L1xx
+  #include "stm32l1xx_hal_i2c.c"
+#elif STM32L4xx
+  #include "stm32l4xx_hal_i2c.c"
+#elif STM32L5xx
+  #include "stm32l5xx_hal_i2c.c"
+#elif STM32MP1xx
+  #include "stm32mp1xx_hal_i2c.c"
+#elif STM32U5xx
+  #include "stm32u5xx_hal_i2c.c"
+#elif STM32WBxx
+  #include "stm32wbxx_hal_i2c.c"
+#elif STM32WLxx
+  #include "stm32wlxx_hal_i2c.c"
+#endif
+#pragma GCC diagnostic pop

--- a/cores/arduino/stm32/HAL/stm32yyxx_hal_i2c_ex.c
+++ b/cores/arduino/stm32/HAL/stm32yyxx_hal_i2c_ex.c
@@ -1,0 +1,36 @@
+/* HAL raised several warnings, ignore them */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
+#ifdef STM32C0xx
+  #include "stm32c0xx_hal_i2c_ex.c"
+#elif STM32F0xx
+  #include "stm32f0xx_hal_i2c_ex.c"
+#elif STM32F3xx
+  #include "stm32f3xx_hal_i2c_ex.c"
+#elif STM32F4xx
+  #include "stm32f4xx_hal_i2c_ex.c"
+#elif STM32F7xx
+  #include "stm32f7xx_hal_i2c_ex.c"
+#elif STM32G0xx
+  #include "stm32g0xx_hal_i2c_ex.c"
+#elif STM32G4xx
+  #include "stm32g4xx_hal_i2c_ex.c"
+#elif STM32H7xx
+  #include "stm32h7xx_hal_i2c_ex.c"
+#elif STM32L0xx
+  #include "stm32l0xx_hal_i2c_ex.c"
+#elif STM32L4xx
+  #include "stm32l4xx_hal_i2c_ex.c"
+#elif STM32L5xx
+  #include "stm32l5xx_hal_i2c_ex.c"
+#elif STM32MP1xx
+  #include "stm32mp1xx_hal_i2c_ex.c"
+#elif STM32U5xx
+  #include "stm32u5xx_hal_i2c_ex.c"
+#elif STM32WBxx
+  #include "stm32wbxx_hal_i2c_ex.c"
+#elif STM32WLxx
+  #include "stm32wlxx_hal_i2c_ex.c"
+#endif
+#pragma GCC diagnostic pop

--- a/cores/arduino/sys/system.cpp
+++ b/cores/arduino/sys/system.cpp
@@ -223,7 +223,7 @@ void System::Init(const System::Config& config)
         ConfigureMpu();
     }
     uvs_dma_init();
-    // uvs_i2c_global_init();
+    uvs_i2c_global_init();
     uvs_spi_global_init();
     uvs_uart_global_init();
 

--- a/cores/arduino/uvos.h
+++ b/cores/arduino/uvos.h
@@ -17,7 +17,7 @@
 // #include "hid/audio.h"
 // #include "util/unique_id.h"
 #ifdef __cplusplus
-// #include "per/i2c.h"
+#include "per/i2c.h"
 // #include "per/adc.h"
 #include "per/uart.h"
 // #include "hid/midi.h"

--- a/examples/I2C/I2C.ino
+++ b/examples/I2C/I2C.ino
@@ -1,0 +1,93 @@
+#include "uvos_brd.h"
+#include <cstring>
+
+// Use the uvos namespace to prevent having to type
+// uvos:: before all libuvos functions
+using namespace uvos;
+
+// Declare a UVOSboard object called hw
+UVOSboard hw;
+UartHandler uart;
+
+I2CHandle i2c_dev;
+static constexpr I2CHandle::Config i2c_dev_config= {
+    I2CHandle::Config::Peripheral::I2C_2,
+    {
+        {UVS_GPIOB, 10}, // SCL
+        {UVS_GPIOB, 11}  // SDA
+    },
+    I2CHandle::Config::Speed::I2C_400KHZ
+};
+
+// Create LED objects
+GPIO led0;
+GPIO led1;
+
+// Create LED pins
+Pin led0_pin = Pin(PORTE, 3);
+Pin led1_pin = Pin(PORTE, 4);
+
+// Function to print a message over uart
+void print_msg(const char* msg)
+{
+    char buf[128];
+    sprintf(buf, "%s\r\n", msg);
+    uart.BlockingTransmit((uint8_t*)buf, strlen(buf));
+}
+
+int main(void)
+{
+    // Declare a variable to store the state we want to set for the LED.
+    bool led_state;
+    led_state = true;
+
+    // Configure and Initialize the UVOS board
+    // These are separate to allow reconfiguration of any of the internal
+    // components before initialization.
+    hw.Configure();
+    hw.Init();
+
+    // Configure the Uart Peripheral
+    UartHandler::Config uart_conf;
+    uart_conf.periph        = UartHandler::Config::Peripheral::USART_3;
+    uart_conf.mode          = UartHandler::Config::Mode::TX;
+    uart_conf.pin_config.tx = Pin(PORTD, 8);
+    uart_conf.pin_config.rx = Pin(PORTD, 9);
+
+    // Initialize the uart peripheral for test results
+    uart.Init(uart_conf);
+
+    print_msg("I2C Scanner test...\r\n\r\n");
+
+    i2c_dev.Init(i2c_dev_config);
+
+    print_msg("Starting I2C Scanning: \r\n");
+
+    char prn_buf[128];
+
+    // Use a GY-85 sensor board for scan test, which has:
+    //   ADXL345 -  0x53 — Three axis acceleration 
+    //   ITG3205  - 0x69 — Three axis gyroscope
+    //   HMC5883L - 0x1E — Three axis magnetic field
+
+    // Scan thru valid I2C addresses
+    for(uint8_t i=1; i<128; i++)
+    {
+        // I2C address shifted left by 1 for LSB read/write bit 
+        if(i2c_dev.IsDeviceReady((uint16_t)(i<<1), 2, 5) == I2CHandle::Result::OK) {
+            // Print the address of the device found
+            sprintf(prn_buf, "I2C device found at address: 0x%02X\r\n", (i<<1));
+            uart.BlockingTransmit((uint8_t*)prn_buf, strlen(prn_buf));
+        } else {
+            // Print the address of the device not found
+            sprintf(prn_buf, "No I2C device at address: 0x%02X\r\n", (i<<1));
+            uart.BlockingTransmit((uint8_t*)prn_buf, strlen(prn_buf));
+        }
+
+        // Toggle the LED state for the next time around.
+        led0.Toggle();
+
+        // Wait 500ms
+        System::Delay(50);
+    }
+}

--- a/examples/I2C/I2C.ino
+++ b/examples/I2C/I2C.ino
@@ -70,14 +70,14 @@ int main(void)
     //   ITG3205  - 0x69 — Three axis gyroscope
     //   HMC5883L - 0x1E — Three axis magnetic field
 
-    // Scan thru valid I2C addresses
+    // Scan thru range of valid 7-bit slave addresses.
+    // Valid slave addresses are >= than 0x08 and <= than 0x77.
     for(uint8_t addr = 0x08; addr <= 0x77; addr++)
     {
         // ST HAL expects 7-bit address passed as left aligned (shift left 1 bit)
         uint16_t HAL_addr = ((uint16_t)addr) << 1;
 
         if (i2c_dev.IsDeviceReady(HAL_addr, 2, 5) == I2CHandle::Result::OK) {
-            // Found a device at 8-bit address = addr
             sprintf(prn_buf, "I2C device found >>> address: 0x%02X\r\n", addr);
             uart.BlockingTransmit((uint8_t*)prn_buf, strlen(prn_buf));
         } else {

--- a/examples/I2C/I2C.ino
+++ b/examples/I2C/I2C.ino
@@ -71,23 +71,23 @@ int main(void)
     //   HMC5883L - 0x1E — Three axis magnetic field
 
     // Scan thru valid I2C addresses
-    for(uint8_t i=1; i<128; i++)
+    for(uint8_t addr = 0x08; addr <= 0x77; addr++)
     {
-        // I2C address shifted left by 1 for LSB read/write bit 
-        if(i2c_dev.IsDeviceReady((uint16_t)(i<<1), 2, 5) == I2CHandle::Result::OK) {
-            // Print the address of the device found
-            sprintf(prn_buf, "I2C device found at address: 0x%02X\r\n", (i<<1));
+        // ST HAL expects 7-bit address passed as left aligned (shift left 1 bit)
+        uint16_t HAL_addr = ((uint16_t)addr) << 1;
+
+        if (i2c_dev.IsDeviceReady(HAL_addr, 2, 5) == I2CHandle::Result::OK) {
+            // Found a device at 8-bit address = addr
+            sprintf(prn_buf, "I2C device found >>> address: 0x%02X\r\n", addr);
             uart.BlockingTransmit((uint8_t*)prn_buf, strlen(prn_buf));
         } else {
-            // Print the address of the device not found
-            sprintf(prn_buf, "No I2C device at address: 0x%02X\r\n", (i<<1));
+            sprintf(prn_buf, "No I2C device at address: 0x%02X\r\n", addr);
             uart.BlockingTransmit((uint8_t*)prn_buf, strlen(prn_buf));
         }
 
         // Toggle the LED state for the next time around.
         led0.Toggle();
 
-        // Wait 500ms
-        System::Delay(50);
+        System::Delay(10);
     }
 }

--- a/examples/uart/Blocking_Transmit/Blocking_Transmit.cpp
+++ b/examples/uart/Blocking_Transmit/Blocking_Transmit.cpp
@@ -1,9 +1,18 @@
 #include "uvos_brd.h"
+#include <cstring>
 
 using namespace uvos;
 
 UVOSboard   hw;
 UartHandler uart;
+
+// Function to print a message over uart
+void print_msg(const char* msg)
+{
+    char buf[128];
+    sprintf(buf, "%s\r\n", msg);
+    uart.BlockingTransmit((uint8_t*)buf, strlen(buf));
+}
 
 int main(void)
 {
@@ -19,6 +28,8 @@ int main(void)
 
     // Initialize the uart peripheral and start the DMA transmit
     uart.Init(uart_conf);
+
+    print_msg("Blocking transmit test...\r\n\r\n");
 
     uint8_t tx = 0;
     while(1) {

--- a/libraries/imu/examples/ReadIMU6/ReadIMU6.ino
+++ b/libraries/imu/examples/ReadIMU6/ReadIMU6.ino
@@ -25,16 +25,7 @@ static int32_t icm_mounting_matrix[9] = { (1 << 30), 0, 0, 0, (1 << 30), 0, 0, 0
 #define USE_SOFT_NSS
 #define DESIRED_SPI_FREQ 1'000'000
 
-#if defined(ARDUINO_FC_MatekH743)
-    constexpr Pin CS_PIN = Pin(PORTC, 15);
-    constexpr Pin SCLK_PIN = Pin(PORTA, 5);
-    constexpr Pin MISO_PIN = Pin(PORTA, 6);
-    constexpr Pin MOSI_PIN = Pin(PORTD, 7);
-    constexpr Pin INT1_PIN = Pin(PORTB, 2);
-    constexpr UartHandler::Config::Peripheral UART_NUM = UartHandler::Config::Peripheral::USART_1;
-    constexpr Pin TX_PIN = Pin(PORTA, 9);
-    constexpr Pin RX_PIN = Pin(PORTA, 10);
-#elif defined(ARDUINO_NUCLEO_H753ZI)
+#if defined(ARDUINO_NUCLEO_H753ZI) || defined(ARDUINO_FC_MatekH743)
     constexpr Pin CS_PIN = Pin(PORTC, 15);
     constexpr Pin SCLK_PIN = Pin(PORTA, 5);
     constexpr Pin MISO_PIN = Pin(PORTA, 6);
@@ -43,7 +34,7 @@ static int32_t icm_mounting_matrix[9] = { (1 << 30), 0, 0, 0, (1 << 30), 0, 0, 0
     constexpr UartHandler::Config::Peripheral UART_NUM = UartHandler::Config::Peripheral::USART_3;
     constexpr Pin TX_PIN = Pin(PORTD, 8);
     constexpr Pin RX_PIN = Pin(PORTD, 9);
-#else // defined(DevEBoxH743VI)
+#else // DevEBoxH743VI
     constexpr Pin CS_PIN = Pin(PORTA, 4);
     constexpr Pin SCLK_PIN = Pin(PORTA, 5);
     constexpr Pin MISO_PIN = Pin(PORTA, 6);
@@ -52,7 +43,7 @@ static int32_t icm_mounting_matrix[9] = { (1 << 30), 0, 0, 0, (1 << 30), 0, 0, 0
     constexpr UartHandler::Config::Peripheral UART_NUM = UartHandler::Config::Peripheral::USART_1;
     constexpr Pin TX_PIN = Pin(PORTA, 9);
     constexpr Pin RX_PIN = Pin(PORTA, 10);
-#endif /* ARDUINO_FC_MatekH743 */
+#endif /* ARDUINO_NUCLEO_H753ZI or ARDUINO_FC_MatekH743 */
 
 constexpr bool off = 0;
 constexpr bool on = 1;
@@ -129,7 +120,7 @@ int main(void)
 
     /* Configure IMU object */
     /* /!\ In this example, the data output frequency will be the faster  between Accel and Gyro odr */
-    rc = imu.ConfigureInvDevice(IMU::gpm4, IMU::dps2000, IMU::accel_odr1k, IMU::gyr_odr1k);
+    imu.ConfigureInvDevice(IMU::gpm4, IMU::dps2000, IMU::accel_odr1k, IMU::gyr_odr1k);
 
     RINGBUFFER_CLEAR(&timestamp_buffer);
 

--- a/libraries/imu/examples/read-data-from-registers/read-data-from-registers.ino
+++ b/libraries/imu/examples/read-data-from-registers/read-data-from-registers.ino
@@ -25,16 +25,7 @@ static int32_t icm_mounting_matrix[9] = { (1 << 30), 0, 0, 0, (1 << 30), 0, 0, 0
 #define USE_SOFT_NSS
 #define DESIRED_SPI_FREQ 1'000'000
 
-#if defined(ARDUINO_FC_MatekH743)
-    constexpr Pin CS_PIN = Pin(PORTC, 15);
-    constexpr Pin SCLK_PIN = Pin(PORTA, 5);
-    constexpr Pin MISO_PIN = Pin(PORTA, 6);
-    constexpr Pin MOSI_PIN = Pin(PORTD, 7);
-    constexpr Pin INT1_PIN = Pin(PORTB, 2);
-    constexpr UartHandler::Config::Peripheral UART_NUM = UartHandler::Config::Peripheral::USART_1;
-    constexpr Pin TX_PIN = Pin(PORTA, 9);
-    constexpr Pin RX_PIN = Pin(PORTA, 10);
-#elif defined(ARDUINO_NUCLEO_H753ZI)
+#if defined(ARDUINO_NUCLEO_H753ZI) || defined(ARDUINO_FC_MatekH743)
     constexpr Pin CS_PIN = Pin(PORTC, 15);
     constexpr Pin SCLK_PIN = Pin(PORTA, 5);
     constexpr Pin MISO_PIN = Pin(PORTA, 6);
@@ -43,7 +34,7 @@ static int32_t icm_mounting_matrix[9] = { (1 << 30), 0, 0, 0, (1 << 30), 0, 0, 0
     constexpr UartHandler::Config::Peripheral UART_NUM = UartHandler::Config::Peripheral::USART_3;
     constexpr Pin TX_PIN = Pin(PORTD, 8);
     constexpr Pin RX_PIN = Pin(PORTD, 9);
-#else // defined(DevEBoxH743VI)
+#else // DevEBoxH743VI
     constexpr Pin CS_PIN = Pin(PORTA, 4);
     constexpr Pin SCLK_PIN = Pin(PORTA, 5);
     constexpr Pin MISO_PIN = Pin(PORTA, 6);
@@ -52,7 +43,7 @@ static int32_t icm_mounting_matrix[9] = { (1 << 30), 0, 0, 0, (1 << 30), 0, 0, 0
     constexpr UartHandler::Config::Peripheral UART_NUM = UartHandler::Config::Peripheral::USART_1;
     constexpr Pin TX_PIN = Pin(PORTA, 9);
     constexpr Pin RX_PIN = Pin(PORTA, 10);
-#endif /* ARDUINO_FC_MatekH743 */
+#endif /* ARDUINO_NUCLEO_H753ZI or ARDUINO_FC_MatekH743 */
 
 constexpr bool off = 0;
 constexpr bool on = 1;
@@ -128,7 +119,7 @@ int main(void)
 
     /* Configure IMU object */
     /* In this example, the data output frequency will be the faster  between Accel and Gyro odr */
-    rc = imu.ConfigureInvDevice(IMU::gpm4, IMU::dps2000, IMU::accel_odr1k, IMU::gyr_odr1k);
+    imu.ConfigureInvDevice(IMU::gpm4, IMU::dps2000, IMU::accel_odr1k, IMU::gyr_odr1k);
 
     RINGBUFFER_CLEAR(&timestamp_buffer);
 

--- a/libraries/imu/examples/selftest/selftest.ino
+++ b/libraries/imu/examples/selftest/selftest.ino
@@ -18,15 +18,7 @@ using namespace uvos;
 #define USE_SOFT_NSS
 #define DESIRED_SPI_FREQ 1'000'000
 
-#if defined(ARDUINO_FC_MatekH743)
-    constexpr Pin CS_PIN = Pin(PORTC, 15);
-    constexpr Pin SCLK_PIN = Pin(PORTA, 5);
-    constexpr Pin MISO_PIN = Pin(PORTA, 6);
-    constexpr Pin MOSI_PIN = Pin(PORTD, 7);
-    constexpr UartHandler::Config::Peripheral UART_NUM = UartHandler::Config::Peripheral::USART_1;
-    constexpr Pin TX_PIN = Pin(PORTA, 9);
-    constexpr Pin RX_PIN = Pin(PORTA, 10);
-#elif defined(ARDUINO_NUCLEO_H753ZI)
+#if defined(ARDUINO_NUCLEO_H753ZI) || defined(ARDUINO_FC_MatekH743)
     constexpr Pin CS_PIN = Pin(PORTC, 15);
     constexpr Pin SCLK_PIN = Pin(PORTA, 5);
     constexpr Pin MISO_PIN = Pin(PORTA, 6);
@@ -34,7 +26,7 @@ using namespace uvos;
     constexpr UartHandler::Config::Peripheral UART_NUM = UartHandler::Config::Peripheral::USART_3;
     constexpr Pin TX_PIN = Pin(PORTD, 8);
     constexpr Pin RX_PIN = Pin(PORTD, 9);
-#else // defined(DevEBoxH743VI)
+#else // DevEBoxH743VI
     constexpr Pin CS_PIN = Pin(PORTA, 4);
     constexpr Pin SCLK_PIN = Pin(PORTA, 5);
     constexpr Pin MISO_PIN = Pin(PORTA, 6);
@@ -42,7 +34,7 @@ using namespace uvos;
     constexpr UartHandler::Config::Peripheral UART_NUM = UartHandler::Config::Peripheral::USART_1;
     constexpr Pin TX_PIN = Pin(PORTA, 9);
     constexpr Pin RX_PIN = Pin(PORTA, 10);
-#endif /* ARDUINO_FC_MatekH743 */
+#endif /* ARDUINO_NUCLEO_H753ZI or ARDUINO_FC_MatekH743 */
 
 constexpr bool off = 0;
 constexpr bool on = 1;


### PR DESCRIPTION
This pull request includes significant changes to the I2C peripheral handling and various examples in the codebase. The most important changes involve the addition of a new `I2CHandle` class, updates to the HAL files to support different STM32 families, and enhancements to example sketches for I2C and UART communication.

### New I2C Peripheral Handling:
* Added a new `I2CHandle` class in `cores/arduino/per/i2c.h` to manage I2C peripherals, including initialization, blocking and DMA transmissions, and data read/write operations.

### HAL File Updates:
* Updated `cores/arduino/stm32/HAL/stm32yyxx_hal_i2c.c` and `stm32yyxx_hal_i2c_ex.c` to include specific HAL files for various STM32 families and suppress unused parameter warnings. [[1]](diffhunk://#diff-e90a0d719f46813a4b66a0263cfc2f561fcc7d44293566d472ec9526f4470c1bR1-R42) [[2]](diffhunk://#diff-7b47db94013a3270779c57063dcc7ac1a68c8bcfb20dade8280dbe4e06f06807R1-R36)

### System Initialization:
* Enabled the global initialization of the I2C peripheral in `cores/arduino/sys/system.cpp` by uncommenting the `uvs_i2c_global_init` call.

### Example Sketches:
* Enhanced the I2C scanner example in `examples/I2C/I2C.ino` to initialize and scan for I2C devices, providing feedback via UART.
* Improved the UART blocking transmit example in `examples/uart/Blocking_Transmit/Blocking_Transmit.cpp` by adding a function to print messages over UART. [[1]](diffhunk://#diff-9f2f0cf20b3d179c7120df8b18d4460728a2711fe8d173b96e153984090cc0b5R2-R16) [[2]](diffhunk://#diff-9f2f0cf20b3d179c7120df8b18d4460728a2711fe8d173b96e153984090cc0b5R32-R33)

### IMU Example Updates:
* Consolidated pin definitions for multiple board types in IMU examples (`ReadIMU6.ino` and `read-data-from-registers.ino`) and removed unused variables. [[1]](diffhunk://#diff-24c1f2a1cb57238f724da857b6db0255e697ab8b82ff75ecf99bbdc8e3c1d2d1L28-R28) [[2]](diffhunk://#diff-24c1f2a1cb57238f724da857b6db0255e697ab8b82ff75ecf99bbdc8e3c1d2d1L46-R37) [[3]](diffhunk://#diff-24c1f2a1cb57238f724da857b6db0255e697ab8b82ff75ecf99bbdc8e3c1d2d1L55-R46) [[4]](diffhunk://#diff-24c1f2a1cb57238f724da857b6db0255e697ab8b82ff75ecf99bbdc8e3c1d2d1L132-R123) [[5]](diffhunk://#diff-0a0fd8430e0bf660dbe102956af1d363ce94eed445d633d0df8871757450f61eL28-R28) [[6]](diffhunk://#diff-0a0fd8430e0bf660dbe102956af1d363ce94eed445d633d0df8871757450f61eL46-R37) [[7]](diffhunk://#diff-0a0fd8430e0bf660dbe102956af1d363ce94eed445d633d0df8871757450f61eL55-R46) [[8]](diffhunk://#diff-0a0fd8430e0bf660dbe102956af1d363ce94eed445d633d0df8871757450f61eL131-R122)